### PR TITLE
Some responsiveness in orgs.scss, cleaned up code/renamed some classes

### DIFF
--- a/client/stylesheets/sass/base.scss
+++ b/client/stylesheets/sass/base.scss
@@ -7,25 +7,32 @@
 
 // Use with h2 tag
 .title {
-    font-size: 52px;
     font-family: 'DINProBold';
     color: $light-blue;
+
+    // Don't want to entirely override responsive text sizing in skeleton.css
+    @media (min-width: 550px) {
+        font-size: 52px;
+    }
 }
 
 // Use with h3 tag
 .subtitle {
-    font-size: 28px;
     font-family: 'DINProMedium', sans-serif;
     color: $light-blue;
+
+    // Don't want to entirely override responsive text sizing in skeleton.css
+    @media (min-width: 550px) {
+        font-size: 28px;
+    }
 }
 
 .title-underline {
     border-color: $blue;
     background-color: $blue;
     color: $light-blue;
-    height: 0.5px;
     width: 200px;
-    margin: 10px auto;
+    margin: 0 auto 40px;
 }
 
 .page-container {

--- a/client/stylesheets/sass/pages/orgs.scss
+++ b/client/stylesheets/sass/pages/orgs.scss
@@ -5,10 +5,6 @@
 .title-row {
   text-align: center;
   margin: 20px 0;
-
-  .clubs-title {
-    text-transform: uppercase;
-  }
 }
 
 
@@ -17,43 +13,53 @@
   margin-top: 15px;
 }
 
-.club-type-list-row {
+.section-nav-row {
   margin: 10px 0;
 
-  ul.club-type-list {
+  ul.section-nav {
     list-style-type: none;
     margin: 0;
     padding: 0;
     text-align: center;
 
-    li.club-type-list-item {
+    li.section-nav-item {
       margin: 10px;
       padding: 1em;
       color: $grey;
       background-color: $light-grey;
       display: inline-block;
+      cursor: pointer;
     }
 
   }
 }
 
-.club-list-title {
+// Should be added to h4.subtitle element
+.section-title {
   font-family: 'DINProMedium';
   color: $light-blue;
+
+  @media screen and (min-width: $toast-breakpoint-medium) {
+    text-align: right;
+  }
 }
 
-.club-list {
+.section-list {
   margin-bottom: 20px;
 
-  .club-list-item {
+  .section-list-item {
     margin-bottom: 20px;
 
-    .club-list-item-title {
+    @media screen and (min-width: $toast-breakpoint-medium) {
+      margin-left: 20px;
+    }
+
+    .section-list-item-title {
         color: $gold;
         cursor: pointer;
       }
 
-      .club-list-item-body {
+      .section-list-item-body {
         display: none;
       }
   }

--- a/client/views/orgs.html
+++ b/client/views/orgs.html
@@ -22,60 +22,60 @@
 			</div>
 		</div>
 
-		<div class="club-type-list-row">
-			<ul class="club-type-list col col--centered">
-				<li class="club-type-list-item">DeCals</li>
-				<li class="club-type-list-item">Global Abroad Organizations</li>
+		<div class="section-nav-row">
+			<ul class="section-nav col col--centered">
+				<li class="section-nav-item">DeCals</li>
+				<li class="section-nav-item">Global Abroad Organizations</li>
 			</ul>
 		</div>
 
-	<div class="club-list-row row">
+	<div class="section-list-row row">
 		<div class="col col--1-of-4">
-			<h3 class="subtitle club-list-title">DeCals</h3 >
+			<h3 class="subtitle section-title">DeCals</h3 >
 		</div>
-		<div class="club-list col col--3-of-4">
-			<div class="club-list-item">
-				<div class="club-list-item-title">
+		<div class="section-list col col--3-of-4">
+			<div class="section-list-item">
+				<div class="section-list-item-title">
 					AAPI Community Health Issues DeCal
 				</div>
-				<div class="club-list-item-body">
+				<div class="section-list-item-body">
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam explicabo ex doloremque, enim perferendis praesentium eos voluptates impedit suscipit quis corrupti quaerat laborum reprehenderit, rem inventore odit eum eveniet veniam quo nesciunt, ratione corporis similique ipsa. Illum, optio possimus accusantium quae libero cum est quas iure cupiditate obcaecati deleniti veniam porro! Cumque explicabo hic qui veritatis rem sunt iusto repudiandae! Facere dolore laborum consequatur ex quos animi earum aliquid impedit quasi commodi ab, enim labore voluptates, vero minus reiciendis quibusdam optio architecto! Iste unde nemo quibusdam, provident recusandae placeat ipsam perspiciatis quaerat, veniam non. Nihil sed nemo autem pariatur fugit?</p>
-					<button class="club-list-item-btn">View Course Website</button>
+					<button>View Course Website</button>
 				</div>
 			</div>
-			<div class="club-list-item">
-				<div class="club-list-item-title">
+			<div class="section-list-item">
+				<div class="section-list-item-title">
 					Critical Understanding of Global Health DeCal
 				</div>
-				<div class="club-list-item-body">
+				<div class="section-list-item-body">
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam explicabo ex doloremque, enim perferendis praesentium eos voluptates impedit suscipit quis corrupti quaerat laborum reprehenderit, rem inventore odit eum eveniet veniam quo nesciunt, ratione corporis similique ipsa. Illum, optio possimus accusantium quae libero cum est quas iure cupiditate obcaecati deleniti veniam porro! Cumque explicabo hic qui veritatis rem sunt iusto repudiandae! Facere dolore laborum consequatur ex quos animi earum aliquid impedit quasi commodi ab, enim labore voluptates, vero minus reiciendis quibusdam optio architecto! Iste unde nemo quibusdam, provident recusandae placeat ipsam perspiciatis quaerat, veniam non. Nihil sed nemo autem pariatur fugit?</p>
-					<button class="club-list-item-btn">View Course Website</button>
+					<button>View Course Website</button>
 				</div>
 		</div>
 	</div>
 </div>
 
-	<div class="club-list-row row">
+	<div class="section-list-row row">
 		<div class="col col--1-of-4">
-			<h3 class="subtitle club-list-title">Global Abroad Organizations</h3 >
+			<h3 class="subtitle section-title">Global Abroad Organizations</h3 >
 		</div>
-		<div class="club-list col col--3-of-4">
-			<div class="club-list-item">
-				<div class="club-list-item-title">
+		<div class="section-list col col--3-of-4">
+			<div class="section-list-item">
+				<div class="section-list-item-title">
 					Berkeley Alliance for Global Health
 				</div>
-				<div class="club-list-item-body">
+				<div class="section-list-item-body">
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam explicabo ex doloremque, enim perferendis praesentium eos voluptates impedit suscipit quis corrupti quaerat laborum reprehenderit, rem inventore odit eum eveniet veniam quo nesciunt, ratione corporis similique ipsa. Illum, optio possimus accusantium quae libero cum est quas iure cupiditate obcaecati deleniti veniam porro! Cumque explicabo hic qui veritatis rem sunt iusto repudiandae! Facere dolore laborum consequatur ex quos animi earum aliquid impedit quasi commodi ab, enim labore voluptates, vero minus reiciendis quibusdam optio architecto! Iste unde nemo quibusdam, provident recusandae placeat ipsam perspiciatis quaerat, veniam non. Nihil sed nemo autem pariatur fugit?</p>
-					<button class="club-list-item-btn">View Course Website</button>
+					<button>View Course Website</button>
 				</div>
 			</div>
-			<div class="club-list-item">
-				<div class="club-list-item-title">
+			<div class="section-list-item">
+				<div class="section-list-item-title">
 				Engineering World Health
 				</div>
-				<div class="club-list-item-body">
+				<div class="section-list-item-body">
 					<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ullam explicabo ex doloremque, enim perferendis praesentium eos voluptates impedit suscipit quis corrupti quaerat laborum reprehenderit, rem inventore odit eum eveniet veniam quo nesciunt, ratione corporis similique ipsa. Illum, optio possimus accusantium quae libero cum est quas iure cupiditate obcaecati deleniti veniam porro! Cumque explicabo hic qui veritatis rem sunt iusto repudiandae! Facere dolore laborum consequatur ex quos animi earum aliquid impedit quasi commodi ab, enim labore voluptates, vero minus reiciendis quibusdam optio architecto! Iste unde nemo quibusdam, provident recusandae placeat ipsam perspiciatis quaerat, veniam non. Nihil sed nemo autem pariatur fugit?</p>
-					<button class="club-list-item-btn">View Course Website</button>
+					<button>View Course Website</button>
 				</div>
 		</div>
 	</div>

--- a/client/views/orgs.js
+++ b/client/views/orgs.js
@@ -73,9 +73,9 @@ Template.orgs.events({
 		});
 	},
 
-  'click .club-list-item-title': function(event, template) {
+  'click .section-list-item-title': function(event, template) {
     var list_item = template.$(event.target).parent();
-    var desc_body = list_item.children('.club-list-item-body');
+    var desc_body = list_item.children('.section-list-item-body');
     desc_body.is(':visible') ? desc_body.slideUp() : desc_body.slideDown();
   }
 });


### PR DESCRIPTION
Done:
- Cleaned up some unnecessary margins in orgs.scss, base.scss 
- Made class names in orgs.scss more general so the code could be copied into base.scss and used on other pages
- Added media query for .title and .subtitle classes so as not to entirely override responsive text sizing in skeleton.css
- Fixed some inconsistencies between the clubs page and the mocks

To do:
- Align more closely to the mocks (e.g. use black links with yellow arrows, not just yellow links everywhere)
- Make the section nav boxes clickable
